### PR TITLE
fw support floating 'all' interface rule

### DIFF
--- a/plugins/module_utils/rule.py
+++ b/plugins/module_utils/rule.py
@@ -154,7 +154,10 @@ class PFSenseRuleModule(PFSenseModuleBase):
         """ validate param interface field when floating is true """
         res = []
         for interface in interfaces.split(','):
-            res.append(self.pfsense.parse_interface(interface))
+            if interface.capitalize() == 'Any':
+                res.append(interface)
+            else:
+                res.append(self.pfsense.parse_interface(interface))
         self._floating_interfaces = interfaces
         return ','.join(res)
 


### PR DESCRIPTION
Add support for 'All' interface when creating floating firewall rule

Before
![изображение](https://github.com/WeirdVoodoo-418/pfsensible-core/assets/109062285/1080b242-edcf-4e7b-8a36-44abd04a7844)


After
![изображение](https://github.com/WeirdVoodoo-418/pfsensible-core/assets/109062285/252cb76c-70e8-4b8f-a767-537004726327)
![изображение](https://github.com/WeirdVoodoo-418/pfsensible-core/assets/109062285/4c057a47-c0b5-4117-a578-991bb4ab2ebf)
